### PR TITLE
set all package versions to 0.0.0

### DIFF
--- a/examples/basic-js/package.json
+++ b/examples/basic-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "basic-js",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -17,6 +17,6 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "next-app-middleware": "workspace:^1.0.0"
+    "next-app-middleware": "workspace:0.0.0"
   }
 }

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next-app-middleware/basic-example",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3003",
@@ -20,6 +20,6 @@
     "typescript": "4.9.3"
   },
   "devDependencies": {
-    "next-app-middleware": "workspace:^1.0.0"
+    "next-app-middleware": "workspace:0.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baked-dev/next-app-middleware",
-  "version": "0.0.0",
+  "version": "0.0.0-canary.0",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next-app-middleware/codegen",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@next-app-middleware/runtime": "workspace:^1.0.0",
+    "@next-app-middleware/runtime": "workspace:0.0.0",
     "@swc/core": "^1.3.21",
     "chokidar": "^3.5.3",
     "fs-extra": "^11.1.0",

--- a/packages/middleware-next/package.json
+++ b/packages/middleware-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-app-middleware",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -19,14 +19,14 @@
     "@swc/core": "^1.3.21",
     "concurrently": "^7.6.0",
     "next": "13.0.6",
-    "tsconfig": "workspace:^0.0.0",
+    "tsconfig": "workspace:0.0.0",
     "typescript": "^4.9.3"
   },
   "peerDependencies": {
     "next": "13.0.6"
   },
   "dependencies": {
-    "@next-app-middleware/codegen": "workspace:^1.0.0",
-    "@next-app-middleware/runtime": "workspace:^1.0.0"
+    "@next-app-middleware/codegen": "workspace:0.0.0",
+    "@next-app-middleware/runtime": "workspace:0.0.0"
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next-app-middleware/runtime",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {
@@ -13,11 +13,11 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "next": "^13.0.6",
+    "next": "^13.1",
     "tsconfig": "workspace:^0.0.0",
     "tsup": "^6.5.0"
   },
   "peerDependencies": {
-    "next": "^13.0.6"
+    "next": "^13.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
       eslint: 8.29.0
       eslint-config-next: 13.1.1
       next: 13.1.1
-      next-app-middleware: workspace:^1.0.0
+      next-app-middleware: workspace:0.0.0
       react: 18.2.0
       react-dom: 18.2.0
       typescript: 4.9.3
@@ -47,7 +47,7 @@ importers:
       eslint: 8.30.0
       eslint-config-next: 13.1.1
       next: 13.1.1
-      next-app-middleware: workspace:^1.0.0
+      next-app-middleware: workspace:0.0.0
       react: 18.2.0
       react-dom: 18.2.0
     dependencies:
@@ -62,7 +62,7 @@ importers:
 
   packages/codegen:
     specifiers:
-      '@next-app-middleware/runtime': workspace:^1.0.0
+      '@next-app-middleware/runtime': workspace:0.0.0
       '@swc/core': ^1.3.21
       '@types/fs-extra': ^9.0.13
       '@types/glob': ^8.0.0
@@ -110,13 +110,13 @@ importers:
 
   packages/middleware-next:
     specifiers:
-      '@next-app-middleware/codegen': workspace:^1.0.0
-      '@next-app-middleware/runtime': workspace:^1.0.0
+      '@next-app-middleware/codegen': workspace:0.0.0
+      '@next-app-middleware/runtime': workspace:0.0.0
       '@swc/cli': ^0.1.57
       '@swc/core': ^1.3.21
       concurrently: ^7.6.0
       next: 13.1.1
-      tsconfig: workspace:^0.0.0
+      tsconfig: workspace:0.0.0
       typescript: ^4.9.3
     dependencies:
       '@next-app-middleware/codegen': link:../codegen


### PR DESCRIPTION
When releasing this module to npm the versions in all sub packages will be replaced with the version in the the root package.json. To make this easier all package versions are 0.0.0 and should never be changed manually.