### PR TITLE
throw error in rewrite and redirect instead of 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ export default rewrite;
  * any request that does not have the `rewrite` cookie set to `true`
  * will fall through to the page file while the ones that do have the
  * cookie set will be rewritten to `/rewritten`
+ * Note: if `void` is returned and no futher handler exist a `MatchingError`
+ * is thrown.
  */
 ```
 

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -1,6 +1,7 @@
 {
   "name": "eslint-config-custom",
   "version": "0.0.0",
+  "private": true,
   "main": "index.js",
   "license": "MIT",
   "dependencies": {

--- a/packages/runtime/src/router/ejected/body/branches/redirect.ts
+++ b/packages/runtime/src/router/ejected/body/branches/redirect.ts
@@ -19,8 +19,16 @@ ${renderSwitchStatement({
     [
       ["'undefined'"],
       `{
-    ${renderBranch(fallback || { type: BranchTypes.NOT_FOUND })}
-    break;
+    ${
+      fallback
+        ? `${renderBranch(fallback)}
+    break;`
+        : `
+        throw new Error(
+          "MatchingError: redirect at ${location} must return a value as no page exists"
+        );
+    `.trim()
+    }
   }`,
     ],
     [

--- a/packages/runtime/src/router/ejected/body/branches/rewrite.ts
+++ b/packages/runtime/src/router/ejected/body/branches/rewrite.ts
@@ -15,9 +15,17 @@ ${renderSwitchStatement({
     [
       ["'undefined'"],
       `{
-    ${renderBranch(fallback || { type: BranchTypes.NOT_FOUND })}
-    break;
-  }`,
+        ${
+          fallback
+            ? `${renderBranch(fallback)}
+        break;`
+            : `
+            throw new Error(
+              "MatchingError: rewrite at ${location} must return a value as neiter a redirect nor a page exists"
+            );
+        `.trim()
+        }
+      }`,
     ],
   ],
   default: `{


### PR DESCRIPTION
This PR changes how rewrite and redirect fallbacks are rendered if there is no fallback:
Instead of rendering a `NOT_FOUND Branch` a `MatcherError` is thrown - this is to avoid catch all segments matching requests to an endpoint without a fallback.