### PR TITLE
add handling for new route.ts file spec

### DIFF
--- a/examples/basic-js/app/[locale]/middleware.js
+++ b/examples/basic-js/app/[locale]/middleware.js
@@ -1,7 +1,7 @@
 /**
  * @type {import("next-app-middleware/runtime").MiddlewareHandler<{ locale: string }>}
  */
-export default (req, res) => {
-  console.log("middleware", req.params.locale);
+export default () => {
+  // console.log("middleware", req.params.locale);
   return;
 };

--- a/examples/basic-js/package.json
+++ b/examples/basic-js/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "eslint-config-js": "workspace:^0.0.0",
-    "next-app-middleware": "workspace:0.0.0"
+    "next-app-middleware": "workspace:0.0.0",
+    "typescript": "^4.9.5"
   }
 }

--- a/examples/basic-js/package.json
+++ b/examples/basic-js/package.json
@@ -17,6 +17,7 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
+    "@types/node": "^17.0.45",
     "eslint-config-js": "workspace:^0.0.0",
     "next-app-middleware": "workspace:0.0.0",
     "typescript": "^4.9.5"

--- a/examples/basic/app/route/[...catchAll]/route.ts
+++ b/examples/basic/app/route/[...catchAll]/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return new NextResponse("Hello world");
+}

--- a/examples/basic/app/route/[dynamic]/route.ts
+++ b/examples/basic/app/route/[dynamic]/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return new NextResponse("Hello world");
+}

--- a/examples/basic/app/route/route.ts
+++ b/examples/basic/app/route/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return new NextResponse("Hello world");
+}

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -12,7 +12,7 @@
     "@types/react": "18.0.26",
     "@types/react-dom": "18.0.9",
     "eslint": "8.29.0",
-    "next": "13.1.6",
+    "next": "13.2.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "4.9.3"

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -12,7 +12,7 @@
     "@types/react": "18.0.26",
     "@types/react-dom": "18.0.9",
     "eslint": "8.29.0",
-    "next": "13.2.4",
+    "next": "latest",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "4.9.3"

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "node": ">=14.0.0"
   },
   "resolutions": {
-    "next": "13.1.6",
-    "eslint-config-next": "13.1.6"
+    "next": "13.2.4",
+    "eslint-config-next": "13.2.4"
   },
   "packageManager": "pnpm@7.13.6"
 }

--- a/packages/codegen/src/build/collect-layout.ts
+++ b/packages/codegen/src/build/collect-layout.ts
@@ -11,6 +11,7 @@ import {
   findPage,
   findRedirect,
   findRewrite,
+  findRoute,
   findStaticForward,
   isCatchAllSegment,
   isRouteGroupSegment,
@@ -156,6 +157,7 @@ const collectLayout = async (
         (external ? "/\\" : "") +
         "/";
   const layoutPage = findPage(filesAndFolders);
+  const route = findRoute(filesAndFolders);
   if (layoutPage && external)
     throw new Error(
       `Error while collecting routing config for "${dir}": page and external can not exist in the same segment.`
@@ -193,6 +195,7 @@ const collectLayout = async (
     rewrite: !!findRewrite(filesAndFolders),
     redirect: !!findRedirect(filesAndFolders),
     page: !!layoutPage,
+    route: !!route,
     external,
     middleware: !!layoutMiddleware,
     children: !external

--- a/packages/codegen/src/build/get-pages.ts
+++ b/packages/codegen/src/build/get-pages.ts
@@ -14,6 +14,24 @@ const getPages = (layout: SegmentLayout): SegmentLayout[] => {
   return result;
 };
 
+export const getRoutes = (layout: SegmentLayout) => {
+  const result: string[] = [];
+  // pages, externals, redirects and rewrites are considered endpoints
+  if (layout.route)
+    result.push(
+      layout.internalPath
+        .split("/")
+        .map((part) =>
+          part.startsWith(":") ? ":" : part.startsWith("*") ? "*" : part
+        )
+        .join("/")
+    );
+  for (const child of Object.values(layout.children)) {
+    result.push(...getRoutes(child));
+  }
+  return result;
+};
+
 export default getPages;
 
 /**

--- a/packages/codegen/src/build/index.ts
+++ b/packages/codegen/src/build/index.ts
@@ -11,9 +11,9 @@ import CancelToken from "../util/CancelToken";
 import logger from "../util/log";
 import collectLayout from "./collect-layout";
 import collectPublicFiles from "./collect-public";
-import { ejectMatcherMap, toMatcherMap } from "./eject";
+import { addRoutesToMap, ejectMatcherMap, toMatcherMap } from "./eject";
 import getConfigRewrites from "./get-config-rewrites";
-import getPages, { getSimilarPages } from "./get-pages";
+import getPages, { getRoutes, getSimilarPages } from "./get-pages";
 import { mergeLayouts, resolveLayouts, validateLayout } from "./layout";
 import readHooksConfig from "./read-config";
 import { flattenMergedRoute, traverseRoute } from "./route";
@@ -83,7 +83,10 @@ const generate = async (isTypescriptPromise: Promise<boolean>) => {
       }
     });
   });
-  const ejectedBranches = ejectMatcherMap(toMatcherMap(routes));
+  const routeEndpoints = getRoutes(layout);
+  const ejectedBranches = ejectMatcherMap(
+    addRoutesToMap(toMatcherMap(routes), routeEndpoints)
+  );
   const ejectedRouter = renderRouter({
     branches: ejectedBranches,
     publicFiles: await publicPromise,

--- a/packages/codegen/src/build/regex.ts
+++ b/packages/codegen/src/build/regex.ts
@@ -13,23 +13,39 @@ export const isRouteGroupSegment = (segment: string) =>
 export const makeFind = (regex: RegExp) => (filesAndFolders: string[]) =>
   filesAndFolders.find((fileOrfolder) => regex.test(fileOrfolder));
 
-export const middlewareRegex = /^(middleware\.(?:t|j)s)$/;
-export const findMiddleware = makeFind(middlewareRegex);
+const make = (regex: RegExp) => ({
+  regex,
+  find: makeFind(regex),
+});
 
-export const pageRegex = /^(page\.(?:tsx|jsx?))$/;
-export const findPage = makeFind(pageRegex);
+export const { regex: middlewareRegex, find: findMiddleware } = make(
+  /^(middleware\.(?:t|j)s)$/
+);
 
-export const externalRegex = /^(external\.(?:t|j)s)$/;
-export const findExternal = makeFind(externalRegex);
+export const { regex: pageRegex, find: findPage } = make(
+  /^(page\.(?:tsx|jsx?))$/
+);
 
-export const dynamicForwardRegex = /^(forward\.dynamic\.(?:t|j)s)$/;
-export const findDynamicForward = makeFind(dynamicForwardRegex);
+export const { regex: routeRegex, find: findRoute } = make(
+  /^(route\.(?:ts|js?))$/
+);
 
-export const staticForwardRegex = /^(forward\.static\.(?:t|j)s)$/;
-export const findStaticForward = makeFind(staticForwardRegex);
+export const { regex: externalRegex, find: findExternal } = make(
+  /^(external\.(?:t|j)s)$/
+);
 
-export const rewriteRegex = /^(rewrite\.(?:t|j)s)$/;
-export const findRewrite = makeFind(rewriteRegex);
+export const { regex: dynamicForwardRegex, find: findDynamicForward } = make(
+  /^(forward\.dynamic\.(?:t|j)s)$/
+);
 
-export const redirectRegex = /^(redirect\.(?:t|j)s)$/;
-export const findRedirect = makeFind(redirectRegex);
+export const { regex: staticForwardRegex, find: findStaticForward } = make(
+  /^(forward\.static\.(?:t|j)s)$/
+);
+
+export const { regex: rewriteRegex, find: findRewrite } = make(
+  /^(rewrite\.(?:t|j)s)$/
+);
+
+export const { regex: redirectRegex, find: findRedirect } = make(
+  /^(redirect\.(?:t|j)s)$/
+);

--- a/packages/codegen/src/dev.ts
+++ b/packages/codegen/src/dev.ts
@@ -25,6 +25,7 @@ const watchConfig = {
     "app/**/external.{ts,js}",
     "app/**/middleware.{ts,js}",
     "app/**/page.{tsx,js,jsx}",
+    "app/**/route.{ts,js}",
     "app/**/redirect.{ts,js}",
     "public/**/*",
   ],

--- a/packages/codegen/src/types.ts
+++ b/packages/codegen/src/types.ts
@@ -14,6 +14,7 @@ export type SegmentLayout = {
   rewrite: boolean;
   redirect: boolean;
   page: boolean;
+  route: boolean;
   external?: string;
   middleware: boolean;
   location: string;

--- a/packages/next-app-middleware/package.json
+++ b/packages/next-app-middleware/package.json
@@ -22,7 +22,7 @@
     "@swc/core": "^1.3.21",
     "@whop-sdk/turbo-module": "0.0.4-canary.1",
     "concurrently": "^7.6.0",
-    "next": "13.2.4",
+    "next": "latest",
     "tsconfig": "workspace:0.0.0",
     "typescript": "^4.9.3"
   },

--- a/packages/next-app-middleware/package.json
+++ b/packages/next-app-middleware/package.json
@@ -22,12 +22,12 @@
     "@swc/core": "^1.3.21",
     "@whop-sdk/turbo-module": "0.0.4-canary.1",
     "concurrently": "^7.6.0",
-    "next": "13.1.6",
+    "next": "13.2.4",
     "tsconfig": "workspace:0.0.0",
     "typescript": "^4.9.3"
   },
   "peerDependencies": {
-    "next": "^13.0.6"
+    "next": "^13.2"
   },
   "dependencies": {
     "@next-app-middleware/codegen": "workspace:0.0.0",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "devDependencies": {
     "@whop-sdk/turbo-module": "0.0.4-canary.1",
-    "next": "13.2.4",
+    "next": "latest",
     "tsconfig": "workspace:^0.0.0",
     "tsup": "^6.5.0"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -18,11 +18,11 @@
   "license": "ISC",
   "devDependencies": {
     "@whop-sdk/turbo-module": "0.0.4-canary.1",
-    "next": "13.1.6",
+    "next": "13.2.4",
     "tsconfig": "workspace:^0.0.0",
     "tsup": "^6.5.0"
   },
   "peerDependencies": {
-    "next": "^13.1.6"
+    "next": "^13.2"
   }
 }

--- a/packages/runtime/src/router/ejected/body/branches/index.ts
+++ b/packages/runtime/src/router/ejected/body/branches/index.ts
@@ -9,10 +9,14 @@ import notFound from "./not-found";
 import renderPathSwitch from "./path-swtich";
 import renderRedirect from "./redirect";
 import renderRewrite from "./rewrite";
+import skip from "./skip";
 import renderStaticForward from "./static-forward";
 
 const renderBranch = (branch: Branch): string => {
   switch (branch.type) {
+    case BranchTypes.SKIP: {
+      return skip;
+    }
     case BranchTypes.MIDDLEWARE: {
       return renderMiddleware(branch);
     }

--- a/packages/runtime/src/router/ejected/body/branches/skip.ts
+++ b/packages/runtime/src/router/ejected/body/branches/skip.ts
@@ -1,0 +1,5 @@
+const skip = `
+  next = true;
+`.trim();
+
+export default skip;

--- a/packages/runtime/src/router/ejected/head/static.ts
+++ b/packages/runtime/src/router/ejected/head/static.ts
@@ -8,7 +8,7 @@ import type {
   ParamType,
   RuntimeNext
 } from "next-app-middleware/runtime";
-import { ResponseCookies } from "next/dist/server/web/spec-extension/cookies/response-cookies";
+import { ResponseCookies } from "next/dist/server/web/spec-extension/cookies";
 import { NextMiddleware, NextResponse } from "next/server";`;
 
 export default staticImports;

--- a/packages/runtime/src/router/ejected/types.ts
+++ b/packages/runtime/src/router/ejected/types.ts
@@ -10,7 +10,12 @@ export enum BranchTypes {
   REWRITE,
   REDIRECT,
   CATCH_ALL,
+  SKIP,
 }
+
+export type EjectedSkip = {
+  type: BranchTypes.SKIP;
+};
 
 export type EjectedMiddleware = {
   type: BranchTypes.MIDDLEWARE;
@@ -93,6 +98,7 @@ export type CatchAllSegment = {
 };
 
 export type Branch =
+  | EjectedSkip
   | EjectedMiddleware
   | EjectedDynamicForward
   | EjectedStaticForward

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,8 @@
 lockfileVersion: 5.4
 
 overrides:
-  next: 13.1.6
-  eslint-config-next: 13.1.6
+  next: 13.2.4
+  eslint-config-next: 13.2.4
 
 importers:
 
@@ -24,7 +24,7 @@ importers:
       '@types/react': 18.0.26
       '@types/react-dom': 18.0.9
       eslint: 8.29.0
-      eslint-config-next: 13.1.6
+      eslint-config-next: 13.2.4
       eslint-config-ts: workspace:^0.0.0
       next: 13.2.4
       next-app-middleware: workspace:0.0.0
@@ -41,7 +41,7 @@ importers:
       typescript: 4.9.3
     devDependencies:
       '@types/node': 17.0.45
-      eslint-config-next: 13.1.6_s5ps7njkmjlaqajutnox5ntcla
+      eslint-config-next: 13.2.4_s5ps7njkmjlaqajutnox5ntcla
       eslint-config-ts: link:../../packages/eslint-config-ts
       next-app-middleware: link:../../packages/next-app-middleware
 
@@ -50,21 +50,23 @@ importers:
       '@next/font': 13.1.6
       eslint: 8.30.0
       eslint-config-js: workspace:^0.0.0
-      eslint-config-next: 13.1.6
-      next: 13.1.6
+      eslint-config-next: 13.2.4
+      next: 13.2.4
       next-app-middleware: workspace:0.0.0
       react: 18.2.0
       react-dom: 18.2.0
+      typescript: ^4.9.5
     dependencies:
       '@next/font': 13.1.6
       eslint: 8.30.0
-      eslint-config-next: 13.1.6_req3y6wneysbxs6mlxvssjag2i
-      next: 13.1.6_biqbaboplfbrettd7655fr4n2y
+      eslint-config-next: 13.2.4_req3y6wneysbxs6mlxvssjag2i
+      next: 13.2.4_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     devDependencies:
       eslint-config-js: link:../../packages/eslint-config-js
       next-app-middleware: link:../../packages/next-app-middleware
+      typescript: 4.9.5
 
   packages/codegen:
     specifiers:
@@ -105,7 +107,7 @@ importers:
       typescript: ^4.9.4
     dependencies:
       eslint-config-prettier: 8.5.0_eslint@7.32.0
-      eslint-config-turbo: 0.0.7_eslint@7.32.0
+      eslint-config-turbo: 0.0.9_eslint@7.32.0
     devDependencies:
       eslint: 7.32.0
       typescript: 4.9.5
@@ -120,7 +122,7 @@ importers:
       typescript: ^4.9.4
     dependencies:
       eslint-config-prettier: 8.5.0_eslint@7.32.0
-      eslint-config-turbo: 0.0.7_eslint@7.32.0
+      eslint-config-turbo: 0.0.9_eslint@7.32.0
     devDependencies:
       '@typescript-eslint/eslint-plugin': 5.51.0_hvob2mnilzlwxjztadamqigvwy
       '@typescript-eslint/parser': 5.51.0_jofidmxrjzhj7l6vknpw5ecvfe
@@ -291,15 +293,11 @@ packages:
   /@humanwhocodes/object-schema/1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
 
-  /@next/env/13.1.6:
-    resolution: {integrity: sha512-s+W9Fdqh5MFk6ECrbnVmmAOwxKQuhGMT7xXHrkYIBMBcTiOqNWhv5KbJIboKR5STXxNXl32hllnvKaffzFaWQg==}
-    dev: false
-
   /@next/env/13.2.4:
     resolution: {integrity: sha512-+Mq3TtpkeeKFZanPturjcXt+KHfKYnLlX6jMLyCrmpq6OOs4i1GqBOAauSkii9QeKCMTYzGppar21JU57b/GEA==}
 
-  /@next/eslint-plugin-next/13.1.6:
-    resolution: {integrity: sha512-o7cauUYsXjzSJkay8wKjpKJf2uLzlggCsGUkPu3lP09Pv97jYlekTC20KJrjQKmSv5DXV0R/uks2ZXhqjNkqAw==}
+  /@next/eslint-plugin-next/13.2.4:
+    resolution: {integrity: sha512-ck1lI+7r1mMJpqLNa3LJ5pxCfOB1lfJncKmRJeJxcJqcngaFwylreLP7da6Rrjr6u2gVRTfmnkSkjc80IiQCwQ==}
     dependencies:
       glob: 7.1.7
 
@@ -307,30 +305,12 @@ packages:
     resolution: {integrity: sha512-AITjmeb1RgX1HKMCiA39ztx2mxeAyxl4ljv2UoSBUGAbFFMg8MO7YAvjHCgFhD39hL7YTbFjol04e/BPBH5RzQ==}
     dev: false
 
-  /@next/swc-android-arm-eabi/13.1.6:
-    resolution: {integrity: sha512-F3/6Z8LH/pGlPzR1AcjPFxx35mPqjE5xZcf+IL+KgbW9tMkp7CYi1y7qKrEWU7W4AumxX/8OINnDQWLiwLasLQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@next/swc-android-arm-eabi/13.2.4:
     resolution: {integrity: sha512-DWlalTSkLjDU11MY11jg17O1gGQzpRccM9Oes2yTqj2DpHndajrXHGxj9HGtJ+idq2k7ImUdJVWS2h2l/EDJOw==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    optional: true
-
-  /@next/swc-android-arm64/13.1.6:
-    resolution: {integrity: sha512-cMwQjnB8vrYkWyK/H0Rf2c2pKIH4RGjpKUDvbjVAit6SbwPDpmaijLio0LWFV3/tOnY6kvzbL62lndVA0mkYpw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-android-arm64/13.2.4:
@@ -341,30 +321,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@next/swc-darwin-arm64/13.1.6:
-    resolution: {integrity: sha512-KKRQH4DDE4kONXCvFMNBZGDb499Hs+xcFAwvj+rfSUssIDrZOlyfJNy55rH5t2Qxed1e4K80KEJgsxKQN1/fyw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@next/swc-darwin-arm64/13.2.4:
     resolution: {integrity: sha512-S6vBl+OrInP47TM3LlYx65betocKUUlTZDDKzTiRDbsRESeyIkBtZ6Qi5uT2zQs4imqllJznVjFd1bXLx3Aa6A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    optional: true
-
-  /@next/swc-darwin-x64/13.1.6:
-    resolution: {integrity: sha512-/uOky5PaZDoaU99ohjtNcDTJ6ks/gZ5ykTQDvNZDjIoCxFe3+t06bxsTPY6tAO6uEAw5f6vVFX5H5KLwhrkZCA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-darwin-x64/13.2.4:
@@ -375,30 +337,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@next/swc-freebsd-x64/13.1.6:
-    resolution: {integrity: sha512-qaEALZeV7to6weSXk3Br80wtFQ7cFTpos/q+m9XVRFggu+8Ib895XhMWdJBzew6aaOcMvYR6KQ6JmHA2/eMzWw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@next/swc-freebsd-x64/13.2.4:
     resolution: {integrity: sha512-kkbzKVZGPaXRBPisoAQkh3xh22r+TD+5HwoC5bOkALraJ0dsOQgSMAvzMXKsN3tMzJUPS0tjtRf1cTzrQ0I5vQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    optional: true
-
-  /@next/swc-linux-arm-gnueabihf/13.1.6:
-    resolution: {integrity: sha512-OybkbC58A1wJ+JrJSOjGDvZzrVEQA4sprJejGqMwiZyLqhr9Eo8FXF0y6HL+m1CPCpPhXEHz/2xKoYsl16kNqw==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-linux-arm-gnueabihf/13.2.4:
@@ -409,30 +353,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@next/swc-linux-arm64-gnu/13.1.6:
-    resolution: {integrity: sha512-yCH+yDr7/4FDuWv6+GiYrPI9kcTAO3y48UmaIbrKy8ZJpi7RehJe3vIBRUmLrLaNDH3rY1rwoHi471NvR5J5NQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@next/swc-linux-arm64-gnu/13.2.4:
     resolution: {integrity: sha512-xzYZdAeq883MwXgcwc72hqo/F/dwUxCukpDOkx/j1HTq/J0wJthMGjinN9wH5bPR98Mfeh1MZJ91WWPnZOedOg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /@next/swc-linux-arm64-musl/13.1.6:
-    resolution: {integrity: sha512-ECagB8LGX25P9Mrmlc7Q/TQBb9rGScxHbv/kLqqIWs2fIXy6Y/EiBBiM72NTwuXUFCNrWR4sjUPSooVBJJ3ESQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-linux-arm64-musl/13.2.4:
@@ -443,30 +369,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@next/swc-linux-x64-gnu/13.1.6:
-    resolution: {integrity: sha512-GT5w2mruk90V/I5g6ScuueE7fqj/d8Bui2qxdw6lFxmuTgMeol5rnzAv4uAoVQgClOUO/MULilzlODg9Ib3Y4Q==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@next/swc-linux-x64-gnu/13.2.4:
     resolution: {integrity: sha512-Ngxh51zGSlYJ4EfpKG4LI6WfquulNdtmHg1yuOYlaAr33KyPJp4HeN/tivBnAHcZkoNy0hh/SbwDyCnz5PFJQQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /@next/swc-linux-x64-musl/13.1.6:
-    resolution: {integrity: sha512-keFD6KvwOPzmat4TCnlnuxJCQepPN+8j3Nw876FtULxo8005Y9Ghcl7ACcR8GoiKoddAq8gxNBrpjoxjQRHeAQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-linux-x64-musl/13.2.4:
@@ -477,15 +385,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@next/swc-win32-arm64-msvc/13.1.6:
-    resolution: {integrity: sha512-OwertslIiGQluFvHyRDzBCIB07qJjqabAmINlXUYt7/sY7Q7QPE8xVi5beBxX/rxTGPIbtyIe3faBE6Z2KywhQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@next/swc-win32-arm64-msvc/13.2.4:
     resolution: {integrity: sha512-q3NJzcfClgBm4HvdcnoEncmztxrA5GXqKeiZ/hADvC56pwNALt3ngDC6t6qr1YW9V/EPDxCYeaX4zYxHciW4Dw==}
     engines: {node: '>= 10'}
@@ -494,30 +393,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@next/swc-win32-ia32-msvc/13.1.6:
-    resolution: {integrity: sha512-g8zowiuP8FxUR9zslPmlju7qYbs2XBtTLVSxVikPtUDQedhcls39uKYLvOOd1JZg0ehyhopobRoH1q+MHlIN/w==}
-    engines: {node: '>= 10'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@next/swc-win32-ia32-msvc/13.2.4:
     resolution: {integrity: sha512-/eZ5ncmHUYtD2fc6EUmAIZlAJnVT2YmxDsKs1Ourx0ttTtvtma/WKlMV5NoUsyOez0f9ExLyOpeCoz5aj+MPXw==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    optional: true
-
-  /@next/swc-win32-x64-msvc/13.1.6:
-    resolution: {integrity: sha512-Ls2OL9hi3YlJKGNdKv8k3X/lLgc3VmLG3a/DeTkAd+lAituJp8ZHmRmm9f9SL84fT3CotlzcgbdaCDfFwFA6bA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-win32-x64-msvc/13.2.4:
@@ -1575,8 +1456,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  /eslint-config-next/13.1.6_req3y6wneysbxs6mlxvssjag2i:
-    resolution: {integrity: sha512-0cg7h5wztg/SoLAlxljZ0ZPUQ7i6QKqRiP4M2+MgTZtxWwNKb2JSwNc18nJ6/kXBI6xYvPraTbQSIhAuVw6czw==}
+  /eslint-config-next/13.2.4_req3y6wneysbxs6mlxvssjag2i:
+    resolution: {integrity: sha512-lunIBhsoeqw6/Lfkd6zPt25w1bn0znLA/JCL+au1HoEpSb4/PpsOYsYtgV/q+YPsoKIOzFyU5xnb04iZnXjUvg==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
       typescript: '>=3.3.1'
@@ -1584,7 +1465,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@next/eslint-plugin-next': 13.1.6
+      '@next/eslint-plugin-next': 13.2.4
       '@rushstack/eslint-patch': 1.2.0
       '@typescript-eslint/parser': 5.51.0_req3y6wneysbxs6mlxvssjag2i
       eslint: 8.30.0
@@ -1600,8 +1481,8 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-config-next/13.1.6_s5ps7njkmjlaqajutnox5ntcla:
-    resolution: {integrity: sha512-0cg7h5wztg/SoLAlxljZ0ZPUQ7i6QKqRiP4M2+MgTZtxWwNKb2JSwNc18nJ6/kXBI6xYvPraTbQSIhAuVw6czw==}
+  /eslint-config-next/13.2.4_s5ps7njkmjlaqajutnox5ntcla:
+    resolution: {integrity: sha512-lunIBhsoeqw6/Lfkd6zPt25w1bn0znLA/JCL+au1HoEpSb4/PpsOYsYtgV/q+YPsoKIOzFyU5xnb04iZnXjUvg==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
       typescript: '>=3.3.1'
@@ -1609,7 +1490,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@next/eslint-plugin-next': 13.1.6
+      '@next/eslint-plugin-next': 13.2.4
       '@rushstack/eslint-patch': 1.2.0
       '@typescript-eslint/parser': 5.51.0_s5ps7njkmjlaqajutnox5ntcla
       eslint: 8.29.0
@@ -1634,13 +1515,13 @@ packages:
       eslint: 7.32.0
     dev: false
 
-  /eslint-config-turbo/0.0.7_eslint@7.32.0:
-    resolution: {integrity: sha512-WbrGlyfs94rOXrhombi1wjIAYGdV2iosgJRndOZtmDQeq5GLTzYmBUCJQZWtLBEBUPCj96RxZ2OL7Cn+xv/Azg==}
+  /eslint-config-turbo/0.0.9_eslint@7.32.0:
+    resolution: {integrity: sha512-j1cTdx3tRmKo0csyfQKhpuT8dynK9oddbK5nmrShoMpXI2qMbxHLYH7MWAid4FmJN8rYympy3VKw5U63Yazycg==}
     peerDependencies:
       eslint: '>6.6.0'
     dependencies:
       eslint: 7.32.0
-      eslint-plugin-turbo: 0.0.7_eslint@7.32.0
+      eslint-plugin-turbo: 0.0.9_eslint@7.32.0
     dev: false
 
   /eslint-import-resolver-node/0.3.6:
@@ -1915,8 +1796,8 @@ packages:
       string.prototype.matchall: 4.0.8
     dev: false
 
-  /eslint-plugin-turbo/0.0.7_eslint@7.32.0:
-    resolution: {integrity: sha512-iajOH8eD4jha3duztGVBD1BEmvNrQBaA/y3HFHf91vMDRYRwH7BpHSDFtxydDpk5ghlhRxG299SFxz7D6z4MBQ==}
+  /eslint-plugin-turbo/0.0.9_eslint@7.32.0:
+    resolution: {integrity: sha512-fEsuSnYU3GLtT+s66mUuzDL1LaSieIx5uk3tPO0ToGv7hI2XzOfP24aPkQItTBGl7kq2JaVkRzPwcnfz8hkp0w==}
     peerDependencies:
       eslint: '>6.6.0'
     dependencies:
@@ -2817,50 +2698,6 @@ packages:
 
   /natural-compare/1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
-
-  /next/13.1.6_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-hHlbhKPj9pW+Cymvfzc15lvhaOZ54l+8sXDXJWm3OBNBzgrVj6hwGPmqqsXg40xO1Leq+kXpllzRPuncpC0Phw==}
-    engines: {node: '>=14.6.0'}
-    hasBin: true
-    peerDependencies:
-      fibers: '>= 3.1.0'
-      node-sass: ^6.0.0 || ^7.0.0
-      react: ^18.2.0
-      react-dom: ^18.2.0
-      sass: ^1.3.0
-    peerDependenciesMeta:
-      fibers:
-        optional: true
-      node-sass:
-        optional: true
-      sass:
-        optional: true
-    dependencies:
-      '@next/env': 13.1.6
-      '@swc/helpers': 0.4.14
-      caniuse-lite: 1.0.30001435
-      postcss: 8.4.14
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      styled-jsx: 5.1.1_react@18.2.0
-    optionalDependencies:
-      '@next/swc-android-arm-eabi': 13.1.6
-      '@next/swc-android-arm64': 13.1.6
-      '@next/swc-darwin-arm64': 13.1.6
-      '@next/swc-darwin-x64': 13.1.6
-      '@next/swc-freebsd-x64': 13.1.6
-      '@next/swc-linux-arm-gnueabihf': 13.1.6
-      '@next/swc-linux-arm64-gnu': 13.1.6
-      '@next/swc-linux-arm64-musl': 13.1.6
-      '@next/swc-linux-x64-gnu': 13.1.6
-      '@next/swc-linux-x64-musl': 13.1.6
-      '@next/swc-win32-arm64-msvc': 13.1.6
-      '@next/swc-win32-ia32-msvc': 13.1.6
-      '@next/swc-win32-x64-msvc': 13.1.6
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-    dev: false
 
   /next/13.2.4_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-g1I30317cThkEpvzfXujf0O4wtaQHtDCLhlivwlTJ885Ld+eOgcz7r3TGQzeU+cSRoNHtD8tsJgzxVdYojFssw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
       eslint: 8.29.0
       eslint-config-next: 13.1.6
       eslint-config-ts: workspace:^0.0.0
-      next: 13.1.6
+      next: 13.2.4
       next-app-middleware: workspace:0.0.0
       react: 18.2.0
       react-dom: 18.2.0
@@ -35,7 +35,7 @@ importers:
       '@types/react': 18.0.26
       '@types/react-dom': 18.0.9
       eslint: 8.29.0
-      next: 13.1.6_biqbaboplfbrettd7655fr4n2y
+      next: 13.2.4_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       typescript: 4.9.3
@@ -135,7 +135,7 @@ importers:
       '@swc/core': ^1.3.21
       '@whop-sdk/turbo-module': 0.0.4-canary.1
       concurrently: ^7.6.0
-      next: 13.1.6
+      next: 13.2.4
       tsconfig: workspace:0.0.0
       typescript: ^4.9.3
     dependencies:
@@ -146,19 +146,19 @@ importers:
       '@swc/core': 1.3.21
       '@whop-sdk/turbo-module': 0.0.4-canary.1
       concurrently: 7.6.0
-      next: 13.1.6_biqbaboplfbrettd7655fr4n2y
+      next: 13.2.4_biqbaboplfbrettd7655fr4n2y
       tsconfig: link:../tsconfig
       typescript: 4.9.5
 
   packages/runtime:
     specifiers:
       '@whop-sdk/turbo-module': 0.0.4-canary.1
-      next: 13.1.6
+      next: 13.2.4
       tsconfig: workspace:^0.0.0
       tsup: ^6.5.0
     devDependencies:
       '@whop-sdk/turbo-module': 0.0.4-canary.1
-      next: 13.1.6_biqbaboplfbrettd7655fr4n2y
+      next: 13.2.4_biqbaboplfbrettd7655fr4n2y
       tsconfig: link:../tsconfig
       tsup: 6.5.0
 
@@ -293,6 +293,10 @@ packages:
 
   /@next/env/13.1.6:
     resolution: {integrity: sha512-s+W9Fdqh5MFk6ECrbnVmmAOwxKQuhGMT7xXHrkYIBMBcTiOqNWhv5KbJIboKR5STXxNXl32hllnvKaffzFaWQg==}
+    dev: false
+
+  /@next/env/13.2.4:
+    resolution: {integrity: sha512-+Mq3TtpkeeKFZanPturjcXt+KHfKYnLlX6jMLyCrmpq6OOs4i1GqBOAauSkii9QeKCMTYzGppar21JU57b/GEA==}
 
   /@next/eslint-plugin-next/13.1.6:
     resolution: {integrity: sha512-o7cauUYsXjzSJkay8wKjpKJf2uLzlggCsGUkPu3lP09Pv97jYlekTC20KJrjQKmSv5DXV0R/uks2ZXhqjNkqAw==}
@@ -309,10 +313,28 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-android-arm-eabi/13.2.4:
+    resolution: {integrity: sha512-DWlalTSkLjDU11MY11jg17O1gGQzpRccM9Oes2yTqj2DpHndajrXHGxj9HGtJ+idq2k7ImUdJVWS2h2l/EDJOw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
     optional: true
 
   /@next/swc-android-arm64/13.1.6:
     resolution: {integrity: sha512-cMwQjnB8vrYkWyK/H0Rf2c2pKIH4RGjpKUDvbjVAit6SbwPDpmaijLio0LWFV3/tOnY6kvzbL62lndVA0mkYpw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-android-arm64/13.2.4:
+    resolution: {integrity: sha512-sRavmUImUCf332Gy+PjIfLkMhiRX1Ez4SI+3vFDRs1N5eXp+uNzjFUK/oLMMOzk6KFSkbiK/3Wt8+dHQR/flNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [android]
@@ -325,10 +347,28 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-darwin-arm64/13.2.4:
+    resolution: {integrity: sha512-S6vBl+OrInP47TM3LlYx65betocKUUlTZDDKzTiRDbsRESeyIkBtZ6Qi5uT2zQs4imqllJznVjFd1bXLx3Aa6A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
     optional: true
 
   /@next/swc-darwin-x64/13.1.6:
     resolution: {integrity: sha512-/uOky5PaZDoaU99ohjtNcDTJ6ks/gZ5ykTQDvNZDjIoCxFe3+t06bxsTPY6tAO6uEAw5f6vVFX5H5KLwhrkZCA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-darwin-x64/13.2.4:
+    resolution: {integrity: sha512-a6LBuoYGcFOPGd4o8TPo7wmv5FnMr+Prz+vYHopEDuhDoMSHOnC+v+Ab4D7F0NMZkvQjEJQdJS3rqgFhlZmKlw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -341,10 +381,28 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-freebsd-x64/13.2.4:
+    resolution: {integrity: sha512-kkbzKVZGPaXRBPisoAQkh3xh22r+TD+5HwoC5bOkALraJ0dsOQgSMAvzMXKsN3tMzJUPS0tjtRf1cTzrQ0I5vQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
     optional: true
 
   /@next/swc-linux-arm-gnueabihf/13.1.6:
     resolution: {integrity: sha512-OybkbC58A1wJ+JrJSOjGDvZzrVEQA4sprJejGqMwiZyLqhr9Eo8FXF0y6HL+m1CPCpPhXEHz/2xKoYsl16kNqw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-linux-arm-gnueabihf/13.2.4:
+    resolution: {integrity: sha512-7qA1++UY0fjprqtjBZaOA6cas/7GekpjVsZn/0uHvquuITFCdKGFCsKNBx3S0Rpxmx6WYo0GcmhNRM9ru08BGg==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
@@ -357,10 +415,28 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-linux-arm64-gnu/13.2.4:
+    resolution: {integrity: sha512-xzYZdAeq883MwXgcwc72hqo/F/dwUxCukpDOkx/j1HTq/J0wJthMGjinN9wH5bPR98Mfeh1MZJ91WWPnZOedOg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@next/swc-linux-arm64-musl/13.1.6:
     resolution: {integrity: sha512-ECagB8LGX25P9Mrmlc7Q/TQBb9rGScxHbv/kLqqIWs2fIXy6Y/EiBBiM72NTwuXUFCNrWR4sjUPSooVBJJ3ESQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-linux-arm64-musl/13.2.4:
+    resolution: {integrity: sha512-8rXr3WfmqSiYkb71qzuDP6I6R2T2tpkmf83elDN8z783N9nvTJf2E7eLx86wu2OJCi4T05nuxCsh4IOU3LQ5xw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -373,10 +449,28 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-linux-x64-gnu/13.2.4:
+    resolution: {integrity: sha512-Ngxh51zGSlYJ4EfpKG4LI6WfquulNdtmHg1yuOYlaAr33KyPJp4HeN/tivBnAHcZkoNy0hh/SbwDyCnz5PFJQQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@next/swc-linux-x64-musl/13.1.6:
     resolution: {integrity: sha512-keFD6KvwOPzmat4TCnlnuxJCQepPN+8j3Nw876FtULxo8005Y9Ghcl7ACcR8GoiKoddAq8gxNBrpjoxjQRHeAQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-linux-x64-musl/13.2.4:
+    resolution: {integrity: sha512-gOvwIYoSxd+j14LOcvJr+ekd9fwYT1RyMAHOp7znA10+l40wkFiMONPLWiZuHxfRk+Dy7YdNdDh3ImumvL6VwA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -389,6 +483,15 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-win32-arm64-msvc/13.2.4:
+    resolution: {integrity: sha512-q3NJzcfClgBm4HvdcnoEncmztxrA5GXqKeiZ/hADvC56pwNALt3ngDC6t6qr1YW9V/EPDxCYeaX4zYxHciW4Dw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
     optional: true
 
   /@next/swc-win32-ia32-msvc/13.1.6:
@@ -397,10 +500,28 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-win32-ia32-msvc/13.2.4:
+    resolution: {integrity: sha512-/eZ5ncmHUYtD2fc6EUmAIZlAJnVT2YmxDsKs1Ourx0ttTtvtma/WKlMV5NoUsyOez0f9ExLyOpeCoz5aj+MPXw==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
     optional: true
 
   /@next/swc-win32-x64-msvc/13.1.6:
     resolution: {integrity: sha512-Ls2OL9hi3YlJKGNdKv8k3X/lLgc3VmLG3a/DeTkAd+lAituJp8ZHmRmm9f9SL84fT3CotlzcgbdaCDfFwFA6bA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-win32-x64-msvc/13.2.4:
+    resolution: {integrity: sha512-0MffFmyv7tBLlji01qc0IaPP/LVExzvj7/R5x1Jph1bTAIj4Vu81yFQWHHQAP6r4ff9Ukj1mBK6MDNVXm7Tcvw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2736,6 +2857,53 @@ packages:
       '@next/swc-win32-arm64-msvc': 13.1.6
       '@next/swc-win32-ia32-msvc': 13.1.6
       '@next/swc-win32-x64-msvc': 13.1.6
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    dev: false
+
+  /next/13.2.4_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-g1I30317cThkEpvzfXujf0O4wtaQHtDCLhlivwlTJ885Ld+eOgcz7r3TGQzeU+cSRoNHtD8tsJgzxVdYojFssw==}
+    engines: {node: '>=14.6.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.4.0
+      fibers: '>= 3.1.0'
+      node-sass: ^6.0.0 || ^7.0.0
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      fibers:
+        optional: true
+      node-sass:
+        optional: true
+      sass:
+        optional: true
+    dependencies:
+      '@next/env': 13.2.4
+      '@swc/helpers': 0.4.14
+      caniuse-lite: 1.0.30001435
+      postcss: 8.4.14
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      styled-jsx: 5.1.1_react@18.2.0
+    optionalDependencies:
+      '@next/swc-android-arm-eabi': 13.2.4
+      '@next/swc-android-arm64': 13.2.4
+      '@next/swc-darwin-arm64': 13.2.4
+      '@next/swc-darwin-x64': 13.2.4
+      '@next/swc-freebsd-x64': 13.2.4
+      '@next/swc-linux-arm-gnueabihf': 13.2.4
+      '@next/swc-linux-arm64-gnu': 13.2.4
+      '@next/swc-linux-arm64-musl': 13.2.4
+      '@next/swc-linux-x64-gnu': 13.2.4
+      '@next/swc-linux-x64-musl': 13.2.4
+      '@next/swc-win32-arm64-msvc': 13.2.4
+      '@next/swc-win32-ia32-msvc': 13.2.4
+      '@next/swc-win32-x64-msvc': 13.2.4
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,7 @@ importers:
   examples/basic-js:
     specifiers:
       '@next/font': 13.1.6
+      '@types/node': ^17.0.45
       eslint: 8.30.0
       eslint-config-js: workspace:^0.0.0
       eslint-config-next: 13.2.4
@@ -64,6 +65,7 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     devDependencies:
+      '@types/node': 17.0.45
       eslint-config-js: link:../../packages/eslint-config-js
       next-app-middleware: link:../../packages/next-app-middleware
       typescript: 4.9.5


### PR DESCRIPTION
this PR makes sure that route.{ts,js} files are matched and skips forwarder and middleware execution for matches.
Reason:
- api routes are very different from page routes and should be handled by separate conventions
- the router only matches GET requests so a good amount of requests targeting routes is already skipped